### PR TITLE
Upgrade support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,20 @@ Here are the variables that need to be set:
 
  Key                    | DEFAULT                                     | Type
 ----------------------- | ------------------------------------------- | -------------
-`openvpn_user_password` | `openvpn`                                   | `string`
-`openvpn_url`           | `ovpn.test.com`                             | `string`
+`openvpn_as_version   ` | `2.5.2`                                     | `string`
 `openvpn_certs_db`      | `/usr/local/openvpn_as/etc/db/certs.db`     | `string`
-`openvpn_user_prop_db`  | `/usr/local/openvpn_as/etc/db/userprop.db`  | `string`
+`openvpn_certs_db`      | `/usr/local/openvpn_as/etc/db/certs.db`     | `string`
 `openvpn_config_db`     | `/usr/local/openvpn_as/etc/db/config.db`    | `string`
-`openvpn_log_db`        | `/usr/local/openvpn_as/etc/db/log.db`       | `string`
-`openvpn_db_user`       | `test`                                      | `string`
 `openvpn_db_password`   | `test`                                      | `string`
-`openvpn_ldap`          | `false`                                     | `boolean`
-`openvpn_ldap_user`     | ``                                          | `string`
+`openvpn_db_user`       | `test`                                      | `string`
 `openvpn_ldap_password` | ``                                          | `string`
-`openvpn_ldap_url`      | ``                                          | `string`
 `openvpn_ldap_port`     | `636`                                       | `integer` 
 `openvpn_ldap_uri`      | ``                                          | `string`
+`openvpn_ldap_url`      | ``                                          | `string`
+`openvpn_ldap_user`     | ``                                          | `string`
+`openvpn_ldap`          | `false`                                     | `boolean`
+`openvpn_log_db`        | `/usr/local/openvpn_as/etc/db/log.db`       | `string`
+`openvpn_os`            | `Ubuntu16`                                  | `string`
+`openvpn_url`           | `ovpn.test.com`                             | `string`
+`openvpn_user_password` | `openvpn`                                   | `string`
+`openvpn_user_prop_db`  | `/usr/local/openvpn_as/etc/db/userprop.db`  | `string`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,14 +1,17 @@
 ---
-openvpn_user_password: openvpn
+openvpn_as_version: 2.5.2
 openvpn_certs_db: /usr/local/openvpn_as/etc/db/certs.db
-openvpn_user_prop_db: /usr/local/openvpn_as/etc/db/userprop.db
 openvpn_config_db: /usr/local/openvpn_as/etc/db/config.db
-openvpn_log_db:  /usr/local/openvpn_as/etc/db/log.db
-openvpn_node_type: PRIMARY 
-openvpn_url: ovpn.test.com
-openvpn_db_user: test
 openvpn_db_password: test
 openvpn_db_port: 3306
-openvpn_ldap_password: blah
+openvpn_db_user: test
+openvpn_installer_url: "http://swupdate.openvpn.org/as/openvpn-as-{{openvpn_as_version}}-{{openvpn_os}}.amd_64.deb"
 openvpn_ldap: false
+openvpn_ldap_password: blah
 openvpn_ldap_port: 636
+openvpn_log_db:  /usr/local/openvpn_as/etc/db/log.db
+openvpn_node_type: PRIMARY
+openvpn_os: Ubuntu16
+openvpn_url: ovpn.test.com
+openvpn_user_password: openvpn
+openvpn_user_prop_db: /usr/local/openvpn_as/etc/db/userprop.db

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
     - libmysqlclient-dev
 
 - name: see if openvpn-AS is installed
-  shell: dpkg-query -l 'openvpn-as'
+  shell: "dpkg-query -l | grep openvpn-as | grep {{openvpn_as_version}}"
   failed_when: false
   ignore_errors: true
   register: dpkg_openvpn_as
@@ -25,7 +25,7 @@
 
 - name: install openvpn-AS
   apt:
-    deb: 'http://swupdate.openvpn.org/as/openvpn-as-2.5.2-Ubuntu16.amd_64.deb'
+    deb: "{{openvpn_installer_url}}"
   when: "'ii' not in dpkg_openvpn_as.stdout"
 
 - name: change openvpn user password


### PR DESCRIPTION
This is changing the install url and the installation check in order to
allow for upgrading of the openvpn-AS. The reason for this is so the
upgrade can be managed by ansible